### PR TITLE
Fixed inaccurate health stat calculations

### DIFF
--- a/poke_battle_sim/core/pokemon.py
+++ b/poke_battle_sim/core/pokemon.py
@@ -201,7 +201,7 @@ class Pokemon:
                 (
                     ((2 * self.base[s] + self.ivs[s] + self.evs[s] // 4) * self.level)
                     // 100
-                    + 5
+                    self.level + 5
                 )
                 * nature_stat_changes[s]
             )

--- a/poke_battle_sim/core/pokemon.py
+++ b/poke_battle_sim/core/pokemon.py
@@ -201,7 +201,7 @@ class Pokemon:
                 (
                     ((2 * self.base[s] + self.ivs[s] + self.evs[s] // 4) * self.level)
                     // 100
-                    self.level + 5
+                    + self.level + 5
                 )
                 * nature_stat_changes[s]
             )


### PR DESCRIPTION
<b>Issue #4</b> 
The health stat was missing the + self.level in its original calculations to factor in the level based on the formula from bulbapedia:
![image](https://github.com/user-attachments/assets/d149e55e-1873-4c77-8f24-d827a6c92fdb)
